### PR TITLE
chore: removing github packages support

### DIFF
--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const core = require('@actions/core');
             const { payload } = context;
             const prBody = payload.pull_request.body || '';
             
@@ -35,9 +36,15 @@ jobs:
               issues.push(`PR description is too short. It should have at least 40 characters or 10 words. Current: ${charCount} characters, ${wordCount} words.`);
             }
             
-            // Check for required sections - only Description is mandatory
+            // Check for required sections - Description and Testing are mandatory
             if (!prBody.includes('## Description')) {
               issues.push(`Missing required section: "## Description"`);
+            }
+            
+            // Testing section is mandatory
+            const testingSection = prBody.match(/## How Has This Been Tested\?[\s\S]*?(?=##|$)/);
+            if (!testingSection) {
+              issues.push(`Missing required section: "## How Has This Been Tested?"`);
             }
             
             // For the "Type of change" section, at least one option must be selected if the section exists

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -8,13 +8,11 @@ jobs:
   check-pr-description:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Check PR Description Length and Checklists
         id: pr-description-check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.3.1
         with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const core = require('@actions/core');
             const { payload } = context;
@@ -37,18 +35,18 @@ jobs:
             }
             
             // Check for required sections - Description and Testing are mandatory
-            if (!prBody.includes('## Description')) {
+            if (!/##\s+Description/i.test(prBody)) {
               issues.push(`Missing required section: "## Description"`);
             }
             
             // Testing section is mandatory
-            const testingSection = prBody.match(/## How Has This Been Tested\?[\s\S]*?(?=##|$)/);
+            const testingSection = prBody.match(/##\s+How\s+Has\s+This\s+Been\s+Tested\?/i);
             if (!testingSection) {
               issues.push(`Missing required section: "## How Has This Been Tested?"`);
             }
             
             // For the "Type of change" section, at least one option must be selected if the section exists
-            const typeOfChangeSection = prBody.match(/## Type of change[\s\S]*?(?=##|$)/);
+            const typeOfChangeSection = prBody.match(/##\s+Type\s+of\s+change[\s\S]*?(?=##|$)/i);
             if (typeOfChangeSection && typeOfChangeSection[0]) {
               const typeSection = typeOfChangeSection[0];
               const typeCheckboxes = typeSection.match(/- \[[xX]\]/g) || [];
@@ -59,19 +57,19 @@ jobs:
             
             // For the "How Has This Been Tested?" section, manual testing is mandatory
             // and at least one of the first two options must be selected if the section exists
-            const testingSection = prBody.match(/## How Has This Been Tested\?[\s\S]*?(?=##|$)/);
-            if (testingSection && testingSection[0]) {
-              const testSection = testingSection[0];
+            const testingSectionContent = prBody.match(/##\s+How\s+Has\s+This\s+Been\s+Tested\?[\s\S]*?(?=##|$)/i);
+            if (testingSectionContent && testingSectionContent[0]) {
+              const testSection = testingSectionContent[0];
               
               // Check if Manual Testing is checked
-              const manualTestingChecked = /- \[[xX]\] Manual testing/.test(testSection);
+              const manualTestingChecked = /- \[[xX]\] Manual testing/i.test(testSection);
               if (!manualTestingChecked) {
                 issues.push(`"Manual testing" checkbox must be checked in the "How Has This Been Tested?" section.`);
               }
               
               // Check if at least one of the first two testing methods is checked
-              const unitTestsChecked = /- \[[xX]\] Unit tests added\/updated/.test(testSection);
-              const examplesTestChecked = /- \[[xX]\] Tested with existing examples/.test(testSection);
+              const unitTestsChecked = /- \[[xX]\] Unit tests added\/updated/i.test(testSection);
+              const examplesTestChecked = /- \[[xX]\] Tested with existing examples/i.test(testSection);
               
               if (!unitTestsChecked && !examplesTestChecked) {
                 issues.push(`At least one automated testing method (Unit tests or Testing with examples) must be selected in the "How Has This Been Tested?" section.`);
@@ -79,7 +77,7 @@ jobs:
             }
             
             // For the "Checklist" section, all items must be checked
-            const checklistSection = prBody.match(/## Checklist:[\s\S]*?(?=##|$)/);
+            const checklistSection = prBody.match(/##\s+Checklist:[\s\S]*?(?=##|$)/i);
             if (checklistSection && checklistSection[0]) {
               const checklist = checklistSection[0];
               const checkboxes = checklist.match(/- \[[ xX]\]/g) || [];

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -1,0 +1,101 @@
+name: PR Description Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, ready_for_review]
+
+jobs:
+  check-pr-description:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check PR Description Length and Checklists
+        id: pr-description-check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { payload } = context;
+            const prBody = payload.pull_request.body || '';
+            
+            // Function to count words (split by whitespace and filter out empty strings)
+            const countWords = (text) => {
+              return text.split(/\s+/).filter(Boolean).length;
+            };
+            
+            // Validation results
+            const issues = [];
+            
+            // Check minimum characters (40) or words (10)
+            const charCount = prBody.length;
+            const wordCount = countWords(prBody);
+            
+            if (charCount < 40 && wordCount < 10) {
+              issues.push(`PR description is too short. It should have at least 40 characters or 10 words. Current: ${charCount} characters, ${wordCount} words.`);
+            }
+            
+            // Check for required sections - only Description is mandatory
+            if (!prBody.includes('## Description')) {
+              issues.push(`Missing required section: "## Description"`);
+            }
+            
+            // For the "Type of change" section, at least one option must be selected if the section exists
+            const typeOfChangeSection = prBody.match(/## Type of change[\s\S]*?(?=##|$)/);
+            if (typeOfChangeSection && typeOfChangeSection[0]) {
+              const typeSection = typeOfChangeSection[0];
+              const typeCheckboxes = typeSection.match(/- \[[xX]\]/g) || [];
+              if (typeCheckboxes.length === 0) {
+                issues.push(`At least one "Type of change" option must be selected.`);
+              }
+            }
+            
+            // For the "How Has This Been Tested?" section, manual testing is mandatory
+            // and at least one of the first two options must be selected if the section exists
+            const testingSection = prBody.match(/## How Has This Been Tested\?[\s\S]*?(?=##|$)/);
+            if (testingSection && testingSection[0]) {
+              const testSection = testingSection[0];
+              
+              // Check if Manual Testing is checked
+              const manualTestingChecked = /- \[[xX]\] Manual testing/.test(testSection);
+              if (!manualTestingChecked) {
+                issues.push(`"Manual testing" checkbox must be checked in the "How Has This Been Tested?" section.`);
+              }
+              
+              // Check if at least one of the first two testing methods is checked
+              const unitTestsChecked = /- \[[xX]\] Unit tests added\/updated/.test(testSection);
+              const examplesTestChecked = /- \[[xX]\] Tested with existing examples/.test(testSection);
+              
+              if (!unitTestsChecked && !examplesTestChecked) {
+                issues.push(`At least one automated testing method (Unit tests or Testing with examples) must be selected in the "How Has This Been Tested?" section.`);
+              }
+            }
+            
+            // For the "Checklist" section, all items must be checked
+            const checklistSection = prBody.match(/## Checklist:[\s\S]*?(?=##|$)/);
+            if (checklistSection && checklistSection[0]) {
+              const checklist = checklistSection[0];
+              const checkboxes = checklist.match(/- \[[ xX]\]/g) || [];
+              const uncheckedBoxes = checklist.match(/- \[ \]/g) || [];
+              
+              if (checkboxes.length > 0 && uncheckedBoxes.length > 0) {
+                issues.push(`All checklist items must be checked. Found ${uncheckedBoxes.length} unchecked item(s) in the Checklist section.`);
+              }
+            }
+            
+            // Output result
+            if (issues.length > 0) {
+              const errorMessage = `## PR Description Issues\n\n${issues.map(issue => `- ${issue}`).join('\n')}`;
+              core.setFailed(errorMessage);
+              
+              // Post comment on PR
+              const { owner, repo, number } = context.issue;
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: number,
+                body: errorMessage
+              });
+            } else {
+              console.log('PR description meets all requirements! ✅');
+            }

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -62,25 +62,8 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      # Publish to npm first
+      # Publish to npm
       - name: Publish to npm
         run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      # Configure for GitHub Packages and publish there too
-      - name: Setup for GitHub Packages
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-          registry-url: 'https://npm.pkg.github.com/'
-          scope: '@ashmeetsehgal'
-      - name: Prepare package.json for GitHub Packages
-        run: |
-          # Use jq to modify the package.json
-          jq '.name = "@ashmeetsehgal/json-deep-compare" | .publishConfig.registry = "https://npm.pkg.github.com"' package.json > package.github.json
-          mv package.github.json package.json
-      - name: Publish to GitHub Packages
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+save-exact=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-@ashmeetsehgal:registry=https://npm.pkg.github.com/
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ The following versions of json-deep-compare are currently supported with securit
 We take the security of json-deep-compare seriously. If you believe you've found a security vulnerability, please follow these steps:
 
 1. **Do not disclose the vulnerability publicly**
-2. **Email the details to [INSERT YOUR CONTACT EMAIL]**
+2. **Email the details to contact@ashmeetsehgal.com**
    - Describe the vulnerability and how it might be exploited
    - Include steps to reproduce if possible
    - Mention your GitHub username if you'd like to be credited

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "json-deep-compare",
-  "version": "1.0.9",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "json-deep-compare",
-      "version": "1.0.9",
+      "version": "1.1.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.14.8",
@@ -22,6 +22,13 @@
         "terser": "^5.39.0",
         "ts-jest": "^27.1.5",
         "typescript": "^4.9.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ashmeetsehgal"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-deep-compare",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A powerful library for comparing JSON objects with support for deep comparison, regex validation, and customizable options",
   "homepage": "https://ashmeetsehgal.com/tools/json-compare",
   "main": "dist/cjs/index.js",
@@ -28,7 +28,7 @@
     "clean": "rm -rf dist",
     "build:cjs": "mkdir -p dist/cjs && babel src --out-dir dist/cjs",
     "build:esm": "mkdir -p dist/esm && babel src --out-dir dist/esm --no-babelrc --config-file ./babel.esm.config.js",
-    "build:copy-package": "node -e \"const pkg = require('./package.json'); const distPkg = { ...pkg }; distPkg.name = 'json-deep-compare'; distPkg.main = './cjs/index.js'; distPkg.module = './esm/index.js'; distPkg.exports = { '.': { 'import': './esm/index.js', 'require': './cjs/index.js' } }; distPkg.types = '../types/index.d.ts'; distPkg.files = ['LICENSE', 'README.md']; delete distPkg.devDependencies; delete distPkg.scripts; if (distPkg.publishConfig) delete distPkg.publishConfig; require('fs').writeFileSync('./dist/package.json', JSON.stringify(distPkg, null, 2));\"",
+    "build:copy-package": "node -e \"const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync('./package.json', 'utf8')); const distPkg = { ...pkg }; distPkg.name = 'json-deep-compare'; distPkg.main = './cjs/index.js'; distPkg.module = './esm/index.js'; distPkg.exports = { '.': { 'import': './esm/index.js', 'require': './cjs/index.js' } }; distPkg.types = '../types/index.d.ts'; distPkg.files = ['LICENSE', 'README.md']; delete distPkg.devDependencies; delete distPkg.scripts; require('fs').writeFileSync('./dist/package.json', JSON.stringify(distPkg, null, 2));\"",
     "build:copy-types": "mkdir -p dist/types && cp -r types/* dist/types/",
     "minify": "for dir in cjs esm; do for file in dist/$dir/*.js dist/$dir/**/*.js; do if [ -f \"$file\" ]; then terser \"$file\" -c -m -o \"$file\"; fi; done; done",
     "prepublishOnly": "npm run build:full",

--- a/scripts/publish-package.js
+++ b/scripts/publish-package.js
@@ -2,7 +2,7 @@
 
 /**
  * Script to publish package to npm
- * Usage: node scripts/publish-packages.js [--dry-run]
+ * Usage: node scripts/publish-package.js [--dry-run]
  */
 
 const fs = require('fs');


### PR DESCRIPTION
## Description

removing github packages support, only npm package is supported 

## Type of change

<!-- Please check the relevant options -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] CI/CD or build process changes

## How Has This Been Tested?

<!-- Please describe how you tested your changes -->

- [ ] Unit tests added/updated
- [x] Tested with existing examples
- [x] Manual testing

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Simplified the publishing workflow to only publish packages to the public npm registry, removing GitHub Packages support.
  - Updated the npm configuration to use the official npm registry and enforce exact version saving.
  - Updated the package version to 1.1.3.
  - Updated the security policy with a specific contact email for vulnerability reporting.
  - Added a new script to automate package publishing with dry-run support.
  - Streamlined existing publishing scripts to focus solely on npm publishing.
  - Added a GitHub Actions workflow to validate pull request descriptions for completeness and compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->